### PR TITLE
添加适配 Windows 系统的 font-family

### DIFF
--- a/assets/sass/_custom.sass
+++ b/assets/sass/_custom.sass
@@ -7,3 +7,6 @@
 
 .footnotes p
   padding: 0.16rem 0
+
+pre, code
+  font-family: 'Lucida Console', 'Monaco', monospace


### PR DESCRIPTION
为 pre 和 code 标签的 font-family 属性添加 'Lucida Console' 字体。

Close #1